### PR TITLE
Small Refactor / Cleanup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,6 @@ export default {
     BlockOptions
   },
   setup() {
-    const blocksStore = useBlocksStore();
     const postId = ref(0);
     const postTitle = ref('');
     const blocks = ref([]);
@@ -129,13 +128,15 @@ export default {
       let htmlContent = '';
       blocks.value.forEach(block => {
         switch (block.type) {
-          case 'header':
+          case 'header': {
             const tag = block.settings.level || 'h2';
             htmlContent += `<${tag}>${block.content}</${tag}>`;
             break;
-          case 'paragraph':
+          }
+          case 'paragraph': {
             htmlContent += `<p>${block.content}</p>`;
             break;
+          }
           default:
             break;
         }

--- a/src/components/EditorCanvas.vue
+++ b/src/components/EditorCanvas.vue
@@ -40,7 +40,7 @@
 </template>
 
 <script>
-import { ref, computed } from 'vue';
+import { ref } from 'vue';
 import draggable from 'vuedraggable';
 import HeaderBlock from './blocks/HeaderBlock.vue';
 import ParagraphBlock from './blocks/ParagraphBlock.vue';

--- a/src/components/blocks/HeaderBlock.vue
+++ b/src/components/blocks/HeaderBlock.vue
@@ -4,8 +4,27 @@
       :is="localBlock.settings.level || 'h2'" 
       class="header-content"
       :style="headerStyles"
-      v-text="localBlock.content"
+      v-model="localBlock.content"
     ></component>
+  </div>
+  <div class="header-block">
+    <label for="header-content">Content:</label>
+    <input 
+      type="text" 
+      id="header-content" 
+      :value="block.content"
+      @input="updateContent"
+    />
+    
+    <label for="header-level">Level:</label>
+    <select id="header-level" :value="block.settings.level" @change="updateLevel">
+      <option value="h1">H1</option>
+      <option value="h2">H2</option>
+      <option value="h3">H3</option>
+      <option value="h4">H4</option>
+      <option value="h5">H5</option>
+      <option value="h6">H6</option>
+    </select>
   </div>
 </template>
 
@@ -62,10 +81,29 @@ export default {
     watch(() => props.block, (newVal) => {
       localBlock.value = { ...newVal };
     });
-    
+
+    const updateContent = (event) => {
+      emit('update:block', {
+        ...props.block,
+        content: event.target.value
+      });
+    };
+
+    const updateLevel = (event) => {
+       emit('update:block', {
+        ...props.block,
+        settings: {
+          ...props.block.settings,
+          level: event.target.value
+        }
+      });
+    };
+
     return {
       localBlock,
-      headerStyles
+      headerStyles,
+      updateContent,
+      updateLevel
     };
   }
 }
@@ -87,5 +125,22 @@ export default {
       background-color: color.adjust(#000000, $alpha: -0.97);
     }
   }
+}
+
+.header-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.header-block label {
+  margin-bottom: 5px;
+}
+
+.header-block input,
+.header-block select {
+  margin-bottom: 10px;
+  padding: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 </style>

--- a/src/components/blocks/ParagraphBlock.vue
+++ b/src/components/blocks/ParagraphBlock.vue
@@ -19,9 +19,7 @@ export default {
     }
   },
   
-  emits: ['update:block'],
-  
-  setup(props, { emit }) {
+  setup(props) {
     const localBlock = ref({ ...props.block });
     
     // Initialize default settings if not present


### PR DESCRIPTION
This pull request includes several updates to the Vue components, focusing on improving the handling of block content and settings, as well as some minor code cleanups. The most important changes are grouped by theme below:

### Enhancements to Block Components:

* [`src/components/blocks/HeaderBlock.vue`](diffhunk://#diff-692e7fb195ac9d159420cd2cd042b063a686a9cc0135b1c77c1e3dde61336546L7-R28): Changed the header block to use `v-model` for binding the content and added input fields for updating the header content and level. This includes new methods `updateContent` and `updateLevel` to emit updates to the parent component. [[1]](diffhunk://#diff-692e7fb195ac9d159420cd2cd042b063a686a9cc0135b1c77c1e3dde61336546L7-R28) [[2]](diffhunk://#diff-692e7fb195ac9d159420cd2cd042b063a686a9cc0135b1c77c1e3dde61336546R85-R106)

### Code Cleanups:

* [`src/App.vue`](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L63): Removed the unused `blocksStore` reference and adjusted the switch cases for block types to use block scoping. [[1]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L63) [[2]](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0L132-R139)
* [`src/components/EditorCanvas.vue`](diffhunk://#diff-dacf0b218cefcd13a70984f473219201eeed8f19ee80ec636662f63d879396c5L43-R43): Removed the unused `computed` import.
* [`src/components/blocks/ParagraphBlock.vue`](diffhunk://#diff-d8fc05e80809107f49334df35d362716fb35926a1e22f609d2f6010052a60758L22-R22): Removed the `emit` parameter from the `setup` function as it was not used.

These changes improve the maintainability and functionality of the block components, ensuring a more user-friendly and efficient content editing experience.