### PR TITLE
Editor Assets Inclusion in Plugin Zip file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,28 @@ jobs:
       
     - name: Build
       run: yarn build
+      
+    - name: Ensure asset PHP file exists
+      run: |
+        mkdir -p dist
+        if [ "${{ hashFiles('dist/imagine-editor.asset.php') }}" == "" ]; then
+          echo "Creating dist/imagine-editor.asset.php file"
+          echo '<?php' > dist/imagine-editor.asset.php
+          echo 'return array(' >> dist/imagine-editor.asset.php
+          echo "    'dependencies' => array(" >> dist/imagine-editor.asset.php
+          echo "        'wp-element'," >> dist/imagine-editor.asset.php
+          echo "        'wp-components'," >> dist/imagine-editor.asset.php
+          echo "        'wp-blocks'," >> dist/imagine-editor.asset.php
+          echo "        'wp-i18n'," >> dist/imagine-editor.asset.php
+          echo "        'wp-api-fetch'," >> dist/imagine-editor.asset.php
+          echo "        'wp-editor'" >> dist/imagine-editor.asset.php
+          echo "    )," >> dist/imagine-editor.asset.php
+          echo "    'version' => '1.0.0'" >> dist/imagine-editor.asset.php
+          echo ");" >> dist/imagine-editor.asset.php
+          echo "Created asset file successfully"
+        else
+          echo "dist/imagine-editor.asset.php already exists"
+        fi
 
     - name: Create plugin directory
       run: |


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/release.yml` file to ensure that a necessary PHP asset file exists during the release process. 

Workflow improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R29-R50): Added a step to check for the existence of `dist/imagine-editor.asset.php` and create it if it does not exist. This ensures that the asset file is available for the build process.