### PR TITLE
Editor Assets Declaration Permanent Location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,28 +25,6 @@ jobs:
       
     - name: Build
       run: yarn build
-      
-    - name: Ensure asset PHP file exists
-      run: |
-        mkdir -p dist
-        if [ "${{ hashFiles('dist/imagine-editor.asset.php') }}" == "" ]; then
-          echo "Creating dist/imagine-editor.asset.php file"
-          echo '<?php' > dist/imagine-editor.asset.php
-          echo 'return array(' >> dist/imagine-editor.asset.php
-          echo "    'dependencies' => array(" >> dist/imagine-editor.asset.php
-          echo "        'wp-element'," >> dist/imagine-editor.asset.php
-          echo "        'wp-components'," >> dist/imagine-editor.asset.php
-          echo "        'wp-blocks'," >> dist/imagine-editor.asset.php
-          echo "        'wp-i18n'," >> dist/imagine-editor.asset.php
-          echo "        'wp-api-fetch'," >> dist/imagine-editor.asset.php
-          echo "        'wp-editor'" >> dist/imagine-editor.asset.php
-          echo "    )," >> dist/imagine-editor.asset.php
-          echo "    'version' => '1.0.0'" >> dist/imagine-editor.asset.php
-          echo ");" >> dist/imagine-editor.asset.php
-          echo "Created asset file successfully"
-        else
-          echo "dist/imagine-editor.asset.php already exists"
-        fi
 
     - name: Verify assets directory structure
       run: |
@@ -71,6 +49,13 @@ jobs:
           echo "Creating placeholder CSS file"
           mkdir -p dist/assets
           echo "/* Imagine Page Builder Editor styles */" > dist/assets/imagine-editor.css
+        fi
+        
+        # Create placeholder blocks CSS file if it doesn't exist
+        if [ ! -f "dist/assets/imagine-blocks.css" ]; then
+          echo "Creating placeholder blocks CSS file"
+          mkdir -p dist/assets
+          echo "/* Imagine Page Builder Blocks styles */" > dist/assets/imagine-blocks.css
         fi
 
     - name: Create plugin directory

--- a/imagine-page-builder.php
+++ b/imagine-page-builder.php
@@ -29,22 +29,38 @@ add_action('plugins_loaded', 'imagine_init');
 
 // Register editor scripts and styles
 function imagine_register_editor_assets() {
-    $asset_file = include(IMAGINE_PATH . 'dist/imagine-editor.asset.php');
+    // Always load the asset file from the includes directory
+    $asset_file = include(IMAGINE_PATH . 'includes/imagine-editor-asset.php');
     
-    wp_register_script(
-        'imagine-editor',
-        IMAGINE_ASSETS_URL . 'imagine-editor.js',
-        $asset_file['dependencies'],
-        $asset_file['version'],
-        true
-    );
+    // Only register scripts if the files exist
+    if (file_exists(IMAGINE_PATH . 'dist/assets/imagine-editor.js')) {
+        wp_register_script(
+            'imagine-editor',
+            IMAGINE_ASSETS_URL . 'imagine-editor.js',
+            $asset_file['dependencies'],
+            $asset_file['version'],
+            true
+        );
+    }
     
-    wp_register_style(
-        'imagine-editor-style',
-        IMAGINE_ASSETS_URL . 'imagine-editor.css',
-        [],
-        $asset_file['version']
-    );
+    if (file_exists(IMAGINE_PATH . 'dist/assets/imagine-editor.css')) {
+        wp_register_style(
+            'imagine-editor-style',
+            IMAGINE_ASSETS_URL . 'imagine-editor.css',
+            [],
+            $asset_file['version']
+        );
+    }
+    
+    // Register frontend block styles if they exist
+    if (file_exists(IMAGINE_PATH . 'dist/assets/imagine-blocks.css')) {
+        wp_register_style(
+            'imagine-blocks-style',
+            IMAGINE_ASSETS_URL . 'imagine-blocks.css',
+            [],
+            $asset_file['version']
+        );
+    }
 }
 add_action('admin_enqueue_scripts', 'imagine_register_editor_assets');
 
@@ -69,7 +85,6 @@ function imagine_save_page_data() {
     ];
     
     wp_update_post($post_data);
-    
     wp_send_json_success();
 }
 add_action('wp_ajax_imagine_save_page_data', 'imagine_save_page_data');

--- a/includes/imagine-editor-asset.php
+++ b/includes/imagine-editor-asset.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Primary asset declarations for Imagine Editor
+ * 
+ * This file defines the script dependencies and versioning for the Imagine editor.
+ * It is the definitive source for asset dependencies in the plugin and is always
+ * loaded regardless of build status.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+return array(
+    'dependencies' => array(
+        'wp-element',
+        'wp-components',
+        'wp-blocks',
+        'wp-i18n',
+        'wp-api-fetch',
+        'wp-editor',
+        'wp-hooks',
+        'jquery'
+    ),
+    'version' => defined('IMAGINE_VERSION') ? IMAGINE_VERSION : '1.0.0'
+);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
+// Note: We're removing the WebpackManifestPlugin since we no longer need to generate the asset file
 
 module.exports = {
   mode: 'production',
@@ -67,25 +67,8 @@ module.exports = {
   plugins: [
     new MiniCssExtractPlugin({
       filename: '[name].css',
-    }),
-    new WebpackManifestPlugin({
-      fileName: '../imagine-editor.asset.php',
-      writeToFileEmit: true,
-      generate: (seed, files) => {
-        return {
-          dependencies: [
-            'wp-element',
-            'wp-components',
-            'wp-blocks',
-            'wp-i18n',
-            'wp-api-fetch',
-            'wp-editor',
-            'wp-hooks'  // Add hooks API for better WordPress integration
-          ],
-          version: require('./package.json').version
-        };
-      }
     })
+    // Removed WebpackManifestPlugin
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
This pull request includes several changes to improve the asset management and build process for the Imagine Page Builder plugin. The most important changes involve removing the generation of the asset PHP file during the build process, ensuring assets are registered only if they exist, and adding a new asset file for dependencies.

### Improvements to asset management:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L29-L50): Removed the step to ensure the `dist/imagine-editor.asset.php` file exists. Instead, added a step to create a placeholder `imagine-blocks.css` file if it doesn't exist. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L29-L50) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R54-R60)
* [`imagine-page-builder.php`](diffhunk://#diff-eeaedae8939573ebbe08cb558b154c117255ad5f09840517bcca578111369d20L32-R64): Modified the `imagine_register_editor_assets` function to always load the asset file from the `includes` directory and register scripts and styles only if the files exist. Added registration for frontend block styles.

### Codebase simplification:

* [`includes/imagine-editor-asset.php`](diffhunk://#diff-830145d35ca8dd995f03a5134ccb4f2000998b1f3bf35976d332e3c56b856ff6R1-R26): Added a new file to define the script dependencies and versioning for the Imagine editor. This file is now the definitive source for asset dependencies.
* [`webpack.config.js`](diffhunk://#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fL3-R3): Removed the `WebpackManifestPlugin` since the asset file is no longer generated during the build process. [[1]](diffhunk://#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fL3-R3) [[2]](diffhunk://#diff-1fb26bc12ac780c7ad7325730ed09fc4c2c3d757c276c3dacc44bfe20faf166fL70-R71)

### Minor code cleanup:

* [`imagine-page-builder.php`](diffhunk://#diff-eeaedae8939573ebbe08cb558b154c117255ad5f09840517bcca578111369d20L72): Removed unnecessary whitespace in the `imagine_save_page_data` function.